### PR TITLE
gzlib needs unistd.h

### DIFF
--- a/3rdparty/zlib/gzguts.h
+++ b/3rdparty/zlib/gzguts.h
@@ -18,6 +18,7 @@
 #  define ZLIB_INTERNAL
 #endif
 
+#include <unistd.h>
 #include <stdio.h>
 #include "zlib.h"
 #ifdef STDC


### PR DESCRIPTION
The lack of `#include <unistd.h>` prevents script `platforms/ios/build_framework.py` from working. This should fix it.

### This pullrequest changes

Add an include in gzlib to get it to compile correctly with the build scripts.